### PR TITLE
fix: typo in docs hints page

### DIFF
--- a/docs/examples/basic/hints.md
+++ b/docs/examples/basic/hints.md
@@ -11,7 +11,7 @@ import { DemoWidget } from "../../../lib/demoWidget.js";
 
 
 You can also add Hints to your page using `data-hint` HTML attributes. Simply add those attributes to your
-elements and call `introjJs().addHints()`:
+elements and call `introJs().addHints()`:
 
 ```jsx title="index.html"
 <div class="card-demo">


### PR DESCRIPTION
Fixed a typo in the hints page of docs.