### PR TITLE
Update goToStepNumber docs to require start() step

### DIFF
--- a/docs/intro/api.md
+++ b/docs/intro/api.md
@@ -80,7 +80,8 @@ Go to specific step of introduction with the concrete step. This differs from `g
 
 ```javascript
 //start introduction from step with data-step='9'
-introJs().goToStepNumber(9).start();
+introJs().start()
+introJs().goToStepNumber(9);
 ``` 
 
 * * *


### PR DESCRIPTION
Existing chaining behavior shown in docs no longer works, see #1770